### PR TITLE
Colorized HUD messages

### DIFF
--- a/App/WRPGconfig.txt
+++ b/App/WRPGconfig.txt
@@ -1,0 +1,2 @@
+colorblind:false
+collect:false

--- a/Source/Archipelago/APRandomizer.h
+++ b/Source/Archipelago/APRandomizer.h
@@ -70,6 +70,8 @@ class APRandomizer {
 		void setPuzzleLocks(HWND loadingHandle);
 
 		std::string buildUri(std::string& server);
+
+		std::array<float, 3> getColorForItem(const APClient::NetworkItem& item);
 };
 
 #define DATAPACKAGE_CACHE "ap_datapackage.json"

--- a/Source/Archipelago/APWatchdog.cpp
+++ b/Source/Archipelago/APWatchdog.cpp
@@ -688,9 +688,9 @@ void APWatchdog::DisplayMessage() {
 
 	if (outstandingMessages.empty()) return;
 
-	std::string message = outstandingMessages.front();
+	HudMessage message = outstandingMessages.front();
 	outstandingMessages.pop();
-	_memory->DisplayHudMessage(message);
+	_memory->DisplayHudMessage(message.text, message.rgbColor);
 	
 	messageCounter = 8;
 }

--- a/Source/Archipelago/APWatchdog.h
+++ b/Source/Archipelago/APWatchdog.h
@@ -10,6 +10,11 @@
 #include "APState.h"
 #include "PanelLocker.h"
 
+struct HudMessage {
+	std::string text;
+	std::array<float, 3> rgbColor;
+};
+
 struct AudioLogMessage {
 	std::string line1;
 	std::string line2;
@@ -59,7 +64,19 @@ public:
 
 	void DoubleDoorTargetHack(int id);
 
-	void queueMessage(std::string message) {
+	void queueMessage(std::string text) {
+		HudMessage message;
+		message.text = text;
+		message.rgbColor = { 1.0f, 1.0f, 1.0f };
+
+		outstandingMessages.push(message);
+	}
+
+	void queueMessage(std::string text, std::array<float, 3> rgbColor) {
+		HudMessage message;
+		message.text = text;
+		message.rgbColor = rgbColor;
+
 		outstandingMessages.push(message);
 	}
 
@@ -90,7 +107,7 @@ private:
 	std::chrono::system_clock::time_point temporarySpeedModificationTime;
 	bool hasEverModifiedSpeed = false;
 
-	std::queue<std::string> outstandingMessages;
+	std::queue<HudMessage> outstandingMessages;
 	int messageCounter = 0;
 
 	std::map<int, AudioLogMessage> audioLogMessageBuffer;

--- a/Source/Memory.h
+++ b/Source/Memory.h
@@ -162,7 +162,7 @@ public:
 
 	void RemoveMesh(int id);
 
-	void DisplayHudMessage(std::string s);
+	void DisplayHudMessage(std::string message, std::array<float, 3> rgbColor);
 
 	void DisplaySubtitles(std::string line1, std::string line2, std::string line3);
 
@@ -180,6 +180,7 @@ public:
 	static uint64_t hudTimePointer;
 	static uint64_t relativeAddressOf6;
 	static uint64_t displayHudFunction;
+	static uint64_t hudMessageColorAddresses[3]; // addresses of constant floats used for HUD message coloring
 	static uint64_t setBoatSpeed;
 	static uint64_t boatSpeed4;
 	static uint64_t boatSpeed3;


### PR DESCRIPTION
This adds the ability to set colors on the popup HUD messages we currently use as system notifications. Additionally, this colorizes the existing item notifications to roughly match AP's coloring schema for item importance.