### PR TITLE
fix: region calculation for puzzles with stones

### DIFF
--- a/Source/Generate.cpp
+++ b/Source/Generate.cpp
@@ -672,7 +672,7 @@ bool Generate::generate_path(PuzzleSymbols & symbols)
 
 	//For stone puzzles, the path must have a certain number of regions
 	if (symbols.style == Panel::Style::HAS_STONES && _splitPoints.size() == 0)
-		return generate_path_regions(std::min(symbols.getNum(Decoration::Stone), (_panel->_width / 2 + _panel->_height / 2) / 2 + 1));
+		return generate_path_regions(std::min(symbols.getNumColors(Decoration::Stone), (_panel->_width / 2 + _panel->_height / 2) / 2 + 1));
 
 	if (symbols.style == Panel::Style::HAS_SHAPERS) {
 		if (hasFlag(Config::SplitShapes)) {

--- a/Source/PuzzleSymbols.h
+++ b/Source/PuzzleSymbols.h
@@ -13,6 +13,11 @@ struct PuzzleSymbols {
 		for (auto& pair : symbols[symbolType]) total += pair.second;
 		return total;
 	}
+	int getNumColors(int symbolType) {
+		int total = 0;
+		for (auto& pair : symbols[symbolType]) total += 1;
+		return total;
+	}
 	bool any(int symbolType) { return symbols[symbolType].size() > 0; }
 	int popRandomSymbol() {
 		std::vector<int> types;


### PR DESCRIPTION
@NewSoupVi The current implementation looks for how many stones are available in the puzzle, but if there is, for example, a puzzle with a 2x2 grid and 2 blue and 2 yellow stones, there should be only 2 regions and not 4 as the current version calculates. I created a new function that calculates the number of unique colors for a given shape. I think this should be more consistent with the expected behavior.