### PR TITLE
Use plain textboxes instead of Rich Edit controls

### DIFF
--- a/Source/ClientWindow.cpp
+++ b/Source/ClientWindow.cpp
@@ -565,7 +565,7 @@ void ClientWindow::addArchipelagoCredentials(int& currentY) {
 		STATIC_TEXT_MARGIN, currentY + SETTING_LABEL_Y_OFFSET,
 		SETTING_LABEL_WIDTH, STATIC_TEXT_HEIGHT,
 		hwndRootWindow, NULL, hAppInstance, NULL);
-	HWND hwndApAddress = CreateWindow(MSFTEDIT_CLASS, L"",
+	HWND hwndApAddress = CreateWindow(L"EDIT", L"",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | WS_BORDER,
 		SETTING_CONTROL_LEFT, currentY,
 		SETTING_CONTROL_WIDTH, CONTROL_HEIGHT,
@@ -581,7 +581,7 @@ void ClientWindow::addArchipelagoCredentials(int& currentY) {
 		STATIC_TEXT_MARGIN, currentY + SETTING_LABEL_Y_OFFSET,
 		SETTING_LABEL_WIDTH, STATIC_TEXT_HEIGHT,
 		hwndRootWindow, NULL, hAppInstance, NULL);
-	HWND hwndApSlotName = CreateWindow(MSFTEDIT_CLASS, L"",
+	HWND hwndApSlotName = CreateWindow(L"EDIT", L"",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | WS_BORDER,
 		SETTING_CONTROL_LEFT, currentY,
 		SETTING_CONTROL_WIDTH, CONTROL_HEIGHT,
@@ -597,7 +597,7 @@ void ClientWindow::addArchipelagoCredentials(int& currentY) {
 		STATIC_TEXT_MARGIN, currentY + SETTING_LABEL_Y_OFFSET,
 		SETTING_LABEL_WIDTH, STATIC_TEXT_HEIGHT,
 		hwndRootWindow, NULL, hAppInstance, NULL);
-	HWND hwndApPassword = CreateWindow(MSFTEDIT_CLASS, L"",
+	HWND hwndApPassword = CreateWindow(L"EDIT", L"",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | WS_BORDER,
 		SETTING_CONTROL_LEFT, currentY,
 		SETTING_CONTROL_WIDTH, CONTROL_HEIGHT,


### PR DESCRIPTION
The client should be using plain textbox controls here, not Rich Edit controls. This fixes two issues:

1. The TAB key can now be used to move between the input textboxes without inserting a tab character by accident.
2. Images can no longer be pasted into these textboxes.

Note: Technically, this PR means that the `LoadLibrary(L"Msftedit.dll");` call in [App/Main.cpp:468](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/blob/50d86d1331a25667e2bd04cc53071db6b0c7377c/App/Main.cpp#L468) should no longer be required, but I've left it because I don't have the compile environment to test whether this is true or not. (I tested this PR by binary-patching the randomiser executable rather than compiling the source.)